### PR TITLE
fix TypeError when reading json

### DIFF
--- a/core/DatasetManager.py
+++ b/core/DatasetManager.py
@@ -21,10 +21,9 @@ class DatasetManager:
         self.dataset_name = dataset_name
         self.label_col = label_col
 
-        dataset_params_file = open(dataset_params_dir / ("%s.json" % self.dataset_name))
-        dataset_params = json.load(dataset_params_file)
-        dataset_params_file.close()
-
+        with open(dataset_params_dir / ("%s.json" % self.dataset_name)) as f:
+            dataset_params = json.load(f)
+            
         self.case_id_col = dataset_params['case_id_col']
         self.activity_col = dataset_params['activity_col']
         self.timestamp_col = dataset_params['timestamp_col']

--- a/core/DatasetManager.py
+++ b/core/DatasetManager.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import os
 from pathlib import Path
@@ -20,7 +21,9 @@ class DatasetManager:
         self.dataset_name = dataset_name
         self.label_col = label_col
 
-        dataset_params = pd.read_json(dataset_params_dir / ("%s.json" % self.dataset_name), orient="index", typ="series")
+        dataset_params_file = open(dataset_params_dir / ("%s.json" % self.dataset_name))
+        dataset_params = json.load(dataset_params_file)
+        dataset_params_file.close()
 
         self.case_id_col = dataset_params['case_id_col']
         self.activity_col = dataset_params['activity_col']
@@ -55,7 +58,7 @@ class DatasetManager:
         group = group.sort_values(self.timestamp_col, ascending=True, kind="mergesort")
         end_date = group[self.timestamp_col].iloc[-1]
         tmp = end_date - group[self.timestamp_col]
-        tmp = tmp.fillna(0)
+        tmp = tmp.fillna(pd.Timedelta(seconds=0))
         group["remtime"] = tmp.apply(lambda x: float(x / np.timedelta64(1, 's')))  # 's' is for seconds
         return group
 

--- a/core/train.py
+++ b/core/train.py
@@ -29,9 +29,9 @@ feature_importance_dir = Path("results/feature_importance/")
 pickles_dir = Path("pkl/")
 
 path_to_open = Path.cwd().parent / training_params_dir / ("%s.json" % config_file)
-configfile = open(path_to_open)
-config = json.load(configfile)
-configfile.close()
+with open(path_to_open) as f:
+    config = json.load(f)
+
 train_file = config["ui_data"]["log_file"]
 dataset_ref = os.path.splitext(os.path.basename(train_file))[0]
 
@@ -287,9 +287,8 @@ with open(str(outfile), 'w') as fout:
 
     # get average scores across all evaluated prefix lengths
     config["evaluation"] = evaluation.get_agg_score(detailed_results.actual, detailed_results.predicted, mode=mode)
-    configfile = open(Path.cwd().parent / training_params_dir / ("%s.json" % config_file), 'w')
-    json.dump(config, configfile)
-    configfile.close()
+    with open(Path.cwd().parent / training_params_dir / ("%s.json" % config_file), 'w') as f:
+        json.dump(config, f)
 
     print("\n")
 

--- a/core/train.py
+++ b/core/train.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pickle
 import sys
@@ -28,7 +29,9 @@ feature_importance_dir = Path("results/feature_importance/")
 pickles_dir = Path("pkl/")
 
 path_to_open = Path.cwd().parent / training_params_dir / ("%s.json" % config_file)
-config = pd.read_json(path_to_open , typ="series", convert_axes=False)
+configfile = open(path_to_open)
+config = json.load(configfile)
+configfile.close()
 train_file = config["ui_data"]["log_file"]
 dataset_ref = os.path.splitext(os.path.basename(train_file))[0]
 
@@ -283,8 +286,10 @@ with open(str(outfile), 'w') as fout:
 
 
     # get average scores across all evaluated prefix lengths
-    config.at["evaluation"] = evaluation.get_agg_score(detailed_results.actual, detailed_results.predicted, mode=mode)
-    config.to_json(Path.cwd().parent / training_params_dir / ("%s.json" % config_file))
+    config["evaluation"] = evaluation.get_agg_score(detailed_results.actual, detailed_results.predicted, mode=mode)
+    configfile = open(Path.cwd().parent / training_params_dir / ("%s.json" % config_file), 'w')
+    json.dump(config, configfile)
+    configfile.close()
 
     print("\n")
 


### PR DESCRIPTION
When I run command "python train.py myconfig_remtime", it always report TypeError at "pd.read_json(...)", like"TypeError: <class 'dict'> is not convertible to datetime".
The original method of reading the json configuration file seems to be invalid in the new pandas version (>= 1.0.1).  So I replaced it with json.load() and json.dump(). 
In addition, in the new version of pandas(>=1.0.1), when we want to use fillna () to fill the date format data with 0, we should use pd.Timedelta (seconds = 0), so I fixed it.
Since I'm not proficient in python, my fix works but may not be optimal :)